### PR TITLE
added group variables to network

### DIFF
--- a/ansible/cldemo-evpn-centralized/hosts
+++ b/ansible/cldemo-evpn-centralized/hosts
@@ -36,3 +36,9 @@ spine
 exit
 edge
 internetrouter
+
+[network:vars]
+ansible_user=cumulus
+ansible_password=CumulusLinux!
+ansible_sudo_pass=CumulusLinux!
+

--- a/ansible/cldemo-evpn-distributed/hosts
+++ b/ansible/cldemo-evpn-distributed/hosts
@@ -36,3 +36,8 @@ spine
 exit
 edge
 internetrouter
+
+[network:vars]
+ansible_user=cumulus
+ansible_password=CumulusLinux!
+ansible_sudo_pass=CumulusLinux!


### PR DESCRIPTION
Hi Dinesh, thank you for the great work on "EVPN In the Data Center". Was trying out the examples and ran into reachability issue from Ansible during setup (ssh from mgmt host was fine): 

cumulus@oob-mgmt-server:~/ansible/cldemo-evpn-centralized$ ansible spine01 -m ping
spine01 | UNREACHABLE! => {
    "changed": false,
    "msg": "Failed to connect to the host via ssh: Warning: Permanently added 'spine01,192.168.0.21' (ECDSA) to the list of known hosts.\r\nPermission denied (publickey,password).\r\n",
    "unreachable": true
}

Was wondering if it was overlooked to include the vars in the inventory file (or elsewhere). So just added the following variables to the two inventory files: 

[network:vars]
ansible_user=cumulus
ansible_password=CumulusLinux!
ansible_sudo_pass=CumulusLinux!

Reachability is ok and Playbook runs for both distributed and centralized topology: 

cumulus@oob-mgmt-server:~/ansible/cldemo-evpn-centralized$ ansible spine01 -m ping
spine01 | SUCCESS => {
    "changed": false,
    "failed": false,
    "ping": "pong"
}

Again, thank you for this book and the previous "BGP in the Data Center" book, I learned a lot from both of them. 
